### PR TITLE
Fix `mtree --check`

### DIFF
--- a/lib/mtree/file_specification.rb
+++ b/lib/mtree/file_specification.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'etc'
+
 module Mtree
   class FileSpecification # rubocop:disable Metrics/ClassLength
     # VALID_ATTRIBUTES = %i[cksum device flags gid gname link md5 mode nlink nochange optional rmd160 sha1 sha256 sha384 sha512 size tags time type uid uname].freeze


### PR DESCRIPTION
Using a simple `bundle exec mtree -f .mtree --check` fails with this error:
```
lib/mtree/file_specification.rb:197:in `current_uname': uninitialized constant Mtree::FileSpecification::Etc (NameError)
```

Ruby version: 2.7
