### PR TITLE
Fix creation of links in place of directories

### DIFF
--- a/lib/mtree/file_specification.rb
+++ b/lib/mtree/file_specification.rb
@@ -86,7 +86,9 @@ module Mtree
       case type
       when 'dir'  then FileUtils.mkdir_p(full_filename(root))
       when 'file' then FileUtils.touch(full_filename(root))
-      when 'link' then FileUtils.ln_s(link, full_filename(root), force: true)
+      when 'link'
+        FileUtils.rm_rf(full_filename(root))
+        FileUtils.ln_s(link, full_filename(root))
       end
       update(root)
     end


### PR DESCRIPTION
If the link name already exist and is a directory, the link will be
created as a file in this directory instead of replacing the actual
directory.

Always recursively remove the new file before creating a link.
